### PR TITLE
introduce kingpin as the cmd framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/ms
 
 #### Binary
 
-Execute `./tape config.yaml 40000` to generate 40000 transactions to Fabric.
+Execute `./tape -c config.yaml -n 40000` to generate 40000 transactions to Fabric.
 
 #### Docker
 
 ```
-docker run -v $PWD:/tmp guoger/tape tape $CONFIG_FILE 40000
+docker run -v $PWD:/tmp guoger/tape tape -c $CONFIG_FILE -n 40000
 ```
 
 *Set this to integer times of batchsize, so that last block is not cut due to timeout*. For example, if you have batch size of 500, set this to 500, 1000, 40000, 100000, etc.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -56,21 +56,39 @@ var _ = Describe("Mock test", func() {
 	})
 
 	Context("E2E with Error Cases", func() {
+		When("Command error", func() {
+			It("should return unexpected command", func() {
+				cmd := exec.Command(tapeBin, "wrongCommand")
+				tapeSession, err := gexec.Start(cmd, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tapeSession.Err).Should(Say("tape: error: unexpected wrongCommand, try --help"))
+			})
+
+			It("should return required flag config", func() {
+				cmd := exec.Command(tapeBin, "-n", "500")
+				tapeSession, err := gexec.Start(cmd, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tapeSession.Err).Should(Say("tape: error: required flag --config not provided, try --help"))
+			})
+
+			It("should return required flag number", func() {
+				cmd := exec.Command(tapeBin, "-c", "TestFile")
+				tapeSession, err := gexec.Start(cmd, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tapeSession.Err).Should(Say("tape: error: required flag --number not provided, try --help"))
+			})
+
+			It("should return help info", func() {
+				cmd := exec.Command(tapeBin, "--help")
+				tapeSession, err := gexec.Start(cmd, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tapeSession.Err).Should(Say("--help  Show context-sensitive help*"))
+			})
+		})
+
 		When("Config error", func() {
-			It("should hit usage", func() {
-				cmd := exec.Command(tapeBin)
-				tapeSession, err := gexec.Start(cmd, nil, nil)
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(tapeSession.Err).Should(Say("error input parameters for tape: tape config.yaml 500"))
-			})
-			It("should hit if not number", func() {
-				cmd := exec.Command(tapeBin, "NoExitFile", "abc")
-				tapeSession, err := gexec.Start(cmd, nil, nil)
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(tapeSession.Err).Should(Say("error input parameters for tape: tape config.yaml 500"))
-			})
 			It("should return file not exist", func() {
-				cmd := exec.Command(tapeBin, "NoExitFile", "500")
+				cmd := exec.Command(tapeBin, "-c", "NoExitFile", "-n", "500")
 				tapeSession, err := gexec.Start(cmd, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(tapeSession.Err).Should(Say("NoExitFile"))
@@ -85,7 +103,7 @@ var _ = Describe("Mock test", func() {
 					Addr:     "N/A",
 				}
 				generateConfigFile(config.Name(), configValue)
-				cmd := exec.Command(tapeBin, config.Name(), "500")
+				cmd := exec.Command(tapeBin, "-c", config.Name(), "-n", "500")
 				tapeSession, err := gexec.Start(cmd, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(tapeSession.Err).Should(Say("error loading priv key"))
@@ -103,7 +121,7 @@ var _ = Describe("Mock test", func() {
 				}
 				generateConfigFile(config.Name(), configValue)
 
-				cmd := exec.Command(tapeBin, config.Name(), "500")
+				cmd := exec.Command(tapeBin, "-c", config.Name(), "-n", "500")
 				tapeSession, err = gexec.Start(cmd, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(tapeSession.Err).Should(Say("error connecting to invalid_addr"))
@@ -132,7 +150,7 @@ var _ = Describe("Mock test", func() {
 				}
 				generateConfigFile(config.Name(), configValue)
 
-				cmd := exec.Command(tapeBin, config.Name(), "500")
+				cmd := exec.Command(tapeBin, "-c", config.Name(), "-n", "500")
 				tapeSession, err = gexec.Start(cmd, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(tapeSession.Out).Should(Say("Time.*Block.*Tx.*10.*"))
@@ -176,7 +194,7 @@ var _ = Describe("Mock test", func() {
 
 				generateConfigFile(config.Name(), configValue)
 
-				cmd := exec.Command(tapeBin, config.Name(), "500")
+				cmd := exec.Command(tapeBin, "-c", config.Name(), "-n", "500")
 				tapeSession, err = gexec.Start(cmd, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(tapeSession.Out).Should(Say("Time.*Block.*Tx.*10.*"))

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed // indirect
 	google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 // indirect
 	google.golang.org/grpc v1.24.0
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,9 @@ github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sE
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -293,6 +295,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -60,4 +60,4 @@ case $1 in
 esac
 
 cd "$DIR"
-docker run  -e TAPE_LOGLEVEL=debug --network host -v $PWD:/config tape tape $CONFIG_FILE 500
+docker run  -e TAPE_LOGLEVEL=debug --network host -v $PWD:/config tape tape -c $CONFIG_FILE -n 500


### PR DESCRIPTION
Currently, only the run and help subcommand is introduced.
Run subcommand has two flags: config and number.
Config flag is the config file's path, whose short flag name is -c.
Number flag is the number of tx for shot, whose short flag name is -n.
Help subcommand just show context-sensitive help, which is provided by the framework.

It's the first change to fix #113 .

Signed-off-by: wuxu <wuxu1103@163.com>