### PR TITLE
add version subcommand

### DIFF
--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -1,9 +1,52 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 	"tape/pkg/infra"
 )
 
+const (
+	loglevel = "TAPE_LOGLEVEL"
+)
+
+var (
+	app = kingpin.New("tape", "A performance test tool for Hyperledger Fabric")
+
+	run     = app.Command("run", "Start the tape program").Default()
+	con     = run.Flag("config", "Path to config file").Required().Short('c').String()
+	num     = run.Flag("number", "Number of tx for shot").Required().Short('n').Int()
+	version = app.Command("version", "Show version information")
+)
+
 func main() {
-	infra.Main()
+	var err error
+
+	logger := log.New()
+	logger.SetLevel(log.WarnLevel)
+	if customerLevel, customerSet := os.LookupEnv(loglevel); customerSet {
+		if lvl, err := log.ParseLevel(customerLevel); err == nil {
+			logger.SetLevel(lvl)
+		}
+	}
+
+	fullCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
+	switch fullCmd {
+	case version.FullCommand():
+		fmt.Printf(infra.GetVersionInfo())
+	case run.FullCommand():
+		err = infra.Process(*con, *num, logger)
+	default:
+		err = errors.Errorf("invalid command: %s", fullCmd)
+	}
+
+	if err != nil {
+		logger.Error(err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -129,6 +129,17 @@ var _ = Describe("Mock test", func() {
 		})
 	})
 
+	Context("E2E with correct subcommand", func() {
+		When("Version subcommand", func() {
+			It("should return version info", func() {
+				cmd := exec.Command(tapeBin, "version")
+				tapeSession, err := gexec.Start(cmd, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tapeSession.Out).Should(Say("tape:\n Version:.*\n Go version:.*\n OS/Arch:.*\n"))
+			})
+		})
+	})
+
 	Context("E2E with mocked Fabric", func() {
 		When("TLS is disabled", func() {
 			It("should work properly", func() {

--- a/pkg/infra/version.go
+++ b/pkg/infra/version.go
@@ -1,0 +1,23 @@
+package infra
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const (
+	programName = "tape"
+	version     = "0.0.2"
+)
+
+// GetVersionInfo return version information
+// TODO add commit hash, Built info
+func GetVersionInfo() string {
+	return fmt.Sprintf(
+		"%s:\n Version: %s\n Go version: %s\n OS/Arch: %s\n",
+		programName,
+		version,
+		runtime.Version(),
+		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	)
+}


### PR DESCRIPTION
The version info is a const value, which is set manually when tape is released.
And integration test will check the version info, which must be consistent with the const value.

This is the second modification to fix #113 .

```
./tape version
tape:
 Version: 0.0.2
 Go version: go1.14.7
 OS/Arch: linux/amd64
```

Signed-off-by: wuxu <wuxu1103@163.com>